### PR TITLE
supported Pillow and fixed README styles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,15 +8,17 @@ Examples
 --------
     .. image:: img/shell8.png
         :alt: Lenna displayed with a color depth of 8 bits.
-Running 'shellpic <image>' in a terminal that supports 256-colors
+
+Running ``shellpic <image>`` in a terminal that supports 256-colors
 will get you something that looks like the image above.
 
 If you happen to have a terminal that is capable of showing true colors,
-you can use the '--shell24'-switch to enable 24bit outout. It will look something like this:
+you can use the ``--shell24``-switch to enable 24bit output. It will look something like this:
+
     .. image:: img/shell24.png
         :alt: Lenna displayed with a color depth of 24 bits.
 
-Shellpic can also be used with irc-clients. Run the script from your client and use the '--irc'-switch, the result will depend on the client used. This is how it looks in xchat:
+Shellpic can also be used with irc-clients. Run the script from your client and use the ``--irc``-switch, the result will depend on the client used. This is how it looks in xchat:
 
     .. image:: img/irc.png
         :alt: Lenna displayed in 16 colors by xchat.
@@ -24,12 +26,20 @@ Shellpic can also be used with irc-clients. Run the script from your client and 
 
 Install
 -------
-You should have PIL installed. Shellpic is tested with Python 2.7.
+You should have PIL_ (>=1.1.7) or Pillow_ (>=1.0) installed. Shellpic is tested with Python 2.7.
 
-If you have PIP installed: 'sudo pip install Shellpic'
+.. _PIL: https://pypi.python.org/pypi/PIL
+.. _Pillow: https://pypi.python.org/pypi/Pillow
 
+If you have PIP installed:
 
-If you do not have PIP or want the bleeding edge version of Shellpic::
+.. code:: sh
+
+   sudo pip install Shellpic
+
+If you do not have PIP or want the bleeding edge version of Shellpic:
+
+.. code:: sh
 
     # clone the repo
     git clone https://github.com/larsjsol/shellpic.git

--- a/bin/shellpic
+++ b/bin/shellpic
@@ -5,7 +5,7 @@
 # Lars Jørgen Solberg <supersolberg@gmail.com> 2014
 #
 import argparse
-import Image
+from PIL import Image
 import sys
 
 import shellpic

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,16 @@
 #
 
 from distutils.core import setup
+import pkg_resources
+
+# Pillow's first version 1.0 was released on 2010-07-31, it's after PIL 1.1.7
+# (2009-11-15), so no need to restrain the version unless it's too new in the
+# future.
+imaging_requires = 'Pillow'
+try:
+    pkg_resources.get_distribution("Pillow")
+except pkg_resources.DistributionNotFound:
+    imaging_requires = 'PIL >= 1.1.7'
 
 setup(
     name='Shellpic',
@@ -19,6 +29,6 @@ setup(
     description='Displays images using shellcodes',
     long_description=open('README.rst').read(),
     install_requires=[
-        "PIL >= 1.1.7",
+        imaging_requires,
     ],
 )


### PR DESCRIPTION
I was trying out Shellpic via `pip` and got error about no PIL, then realized my system has [Pillow](https://pypi.python.org/pypi/Pillow), which is a fork of old PIL. So, I cloned the repository, but got an import error about `Image` module can't be found.

I made a quick file by using `from PIL` import, then I thought I could make the old PIL dependency more flexible with Pillow, hence this pull request.

I tested on Python 2.7.5 with Pillow 2.0.0. Please take look at the comments in `setup.py`, Pillow version isn't checked. The interface might be the same from 1.0 to 2.3.0 (latest), or just Shellpic doesn't use something has been changed.
